### PR TITLE
fix: 修复多处适配器关键缺陷

### DIFF
--- a/internal/adapter/dingtalk_enterprise/adapter.go
+++ b/internal/adapter/dingtalk_enterprise/adapter.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -20,6 +21,13 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/dto"
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
+)
+
+var (
+	errDingtalkMissingAppKey        = errors.New("app_key is required in dingtalk enterprise config")
+	errDingtalkMissingAppSecret     = errors.New("app_secret is required in dingtalk enterprise config")
+	errDingtalkMissingWebhookSecret = errors.New("app_secret is required in dingtalk enterprise config for webhook verification")
+	errDingtalkWebhookSigFailed     = errors.New("webhook signature verification failed")
 )
 
 const (
@@ -72,15 +80,16 @@ func (a *DingtalkEnterpriseAdapter) ValidateConfig(cfg map[string]interface{}) e
 	return config.ValidatePlatformConfig(entity.PlatformTypeDingtalk, cfg)
 }
 
-// GetAccessToken 实现TokenManager接口
+// GetAccessToken 实现TokenManager接口。
 func (a *DingtalkEnterpriseAdapter) GetAccessToken(ctx context.Context, config map[string]interface{}) (*dto.AccessTokenResponse, error) {
 	appKey, ok := config["app_key"].(string)
 	if !ok || appKey == "" {
-		return nil, fmt.Errorf("app_key is required in dingtalk enterprise config")
+		return nil, errDingtalkMissingAppKey
 	}
+
 	appSecret, ok := config["app_secret"].(string)
 	if !ok || appSecret == "" {
-		return nil, fmt.Errorf("app_secret is required in dingtalk enterprise config")
+		return nil, errDingtalkMissingAppSecret
 	}
 
 	// 检查缓存
@@ -198,42 +207,48 @@ func (a *DingtalkEnterpriseAdapter) RegisterWebhookHandler(channelID string, han
 	a.webhookHandlers[channelID] = handler
 }
 
-// VerifyWebhook 实现WebhookProcessor接口
-func (a *DingtalkEnterpriseAdapter) VerifyWebhook(ctx context.Context, signature, timestamp, nonce string, body []byte, cfg map[string]interface{}) error {
+// VerifyWebhook 实现WebhookProcessor接口。
+func (a *DingtalkEnterpriseAdapter) VerifyWebhook(_ context.Context, signature, timestamp, _ string, _ []byte, cfg map[string]interface{}) error {
 	appSecret, ok := cfg["app_secret"].(string)
 	if !ok || appSecret == "" {
-		return fmt.Errorf("app_secret is required in dingtalk enterprise config for webhook verification")
+		return errDingtalkMissingWebhookSecret
 	}
+
 	if !a.verifyWebhookSignature(timestamp, appSecret, signature) {
 		a.logger.Warn().
 			Str("signature", signature).
 			Str("timestamp", timestamp).
 			Msg("钉钉企业应用Webhook签名验证失败")
-		return fmt.Errorf("webhook signature verification failed")
+
+		return errDingtalkWebhookSigFailed
 	}
+
 	return nil
 }
 
-// ParseInboundMessage 实现WebhookProcessor接口
-func (a *DingtalkEnterpriseAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
+// ParseInboundMessage 实现WebhookProcessor接口。
+func (a *DingtalkEnterpriseAdapter) ParseInboundMessage(_ context.Context, body []byte, _ map[string]interface{}) (*dto.UnifiedMessage, error) {
 	var webhookData DingtalkWebhookData
 	if err := json.Unmarshal(body, &webhookData); err != nil {
 		return nil, fmt.Errorf("failed to parse dingtalk enterprise webhook data: %w", err)
 	}
+
 	return webhookData.ToUnifiedMessage(), nil
 }
 
-// BuildWebhookPath 实现WebhookProcessor接口
+// BuildWebhookPath 实现WebhookProcessor接口。
 func (a *DingtalkEnterpriseAdapter) BuildWebhookPath(channelID int64) string {
 	return fmt.Sprintf("/webhook/dingtalk/%d", channelID)
 }
 
-// 编译期接口实现检查
-var _ port.MessageSender = (*DingtalkEnterpriseAdapter)(nil)
-var _ port.TokenManager = (*DingtalkEnterpriseAdapter)(nil)
-var _ port.WebhookProcessor = (*DingtalkEnterpriseAdapter)(nil)
-var _ port.PlatformIdentifier = (*DingtalkEnterpriseAdapter)(nil)
-var _ port.ConfigValidator = (*DingtalkEnterpriseAdapter)(nil)
+// 编译期接口实现检查。
+var (
+	_ port.MessageSender      = (*DingtalkEnterpriseAdapter)(nil)
+	_ port.TokenManager       = (*DingtalkEnterpriseAdapter)(nil)
+	_ port.WebhookProcessor   = (*DingtalkEnterpriseAdapter)(nil)
+	_ port.PlatformIdentifier = (*DingtalkEnterpriseAdapter)(nil)
+	_ port.ConfigValidator    = (*DingtalkEnterpriseAdapter)(nil)
+)
 
 // sendWorkNotice 发送工作通知
 func (a *DingtalkEnterpriseAdapter) sendWorkNotice(ctx context.Context, message *dto.UnifiedMessage, config map[string]interface{}, accessToken string) error {

--- a/internal/adapter/dingtalk_enterprise/adapter.go
+++ b/internal/adapter/dingtalk_enterprise/adapter.go
@@ -74,11 +74,13 @@ func (a *DingtalkEnterpriseAdapter) ValidateConfig(cfg map[string]interface{}) e
 
 // GetAccessToken 实现TokenManager接口
 func (a *DingtalkEnterpriseAdapter) GetAccessToken(ctx context.Context, config map[string]interface{}) (*dto.AccessTokenResponse, error) {
-	appKey, _ := config["app_key"].(string)
-	appSecret, _ := config["app_secret"].(string)
-
-	if appKey == "" || appSecret == "" {
-		return nil, fmt.Errorf("app_key and app_secret are required")
+	appKey, ok := config["app_key"].(string)
+	if !ok || appKey == "" {
+		return nil, fmt.Errorf("app_key is required in dingtalk enterprise config")
+	}
+	appSecret, ok := config["app_secret"].(string)
+	if !ok || appSecret == "" {
+		return nil, fmt.Errorf("app_secret is required in dingtalk enterprise config")
 	}
 
 	// 检查缓存
@@ -195,6 +197,43 @@ func (a *DingtalkEnterpriseAdapter) RegisterWebhookHandler(channelID string, han
 	defer a.handlerMutex.Unlock()
 	a.webhookHandlers[channelID] = handler
 }
+
+// VerifyWebhook 实现WebhookProcessor接口
+func (a *DingtalkEnterpriseAdapter) VerifyWebhook(ctx context.Context, signature, timestamp, nonce string, body []byte, cfg map[string]interface{}) error {
+	appSecret, ok := cfg["app_secret"].(string)
+	if !ok || appSecret == "" {
+		return fmt.Errorf("app_secret is required in dingtalk enterprise config for webhook verification")
+	}
+	if !a.verifyWebhookSignature(timestamp, appSecret, signature) {
+		a.logger.Warn().
+			Str("signature", signature).
+			Str("timestamp", timestamp).
+			Msg("钉钉企业应用Webhook签名验证失败")
+		return fmt.Errorf("webhook signature verification failed")
+	}
+	return nil
+}
+
+// ParseInboundMessage 实现WebhookProcessor接口
+func (a *DingtalkEnterpriseAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
+	var webhookData DingtalkWebhookData
+	if err := json.Unmarshal(body, &webhookData); err != nil {
+		return nil, fmt.Errorf("failed to parse dingtalk enterprise webhook data: %w", err)
+	}
+	return webhookData.ToUnifiedMessage(), nil
+}
+
+// BuildWebhookPath 实现WebhookProcessor接口
+func (a *DingtalkEnterpriseAdapter) BuildWebhookPath(channelID int64) string {
+	return fmt.Sprintf("/webhook/dingtalk/%d", channelID)
+}
+
+// 编译期接口实现检查
+var _ port.MessageSender = (*DingtalkEnterpriseAdapter)(nil)
+var _ port.TokenManager = (*DingtalkEnterpriseAdapter)(nil)
+var _ port.WebhookProcessor = (*DingtalkEnterpriseAdapter)(nil)
+var _ port.PlatformIdentifier = (*DingtalkEnterpriseAdapter)(nil)
+var _ port.ConfigValidator = (*DingtalkEnterpriseAdapter)(nil)
 
 // sendWorkNotice 发送工作通知
 func (a *DingtalkEnterpriseAdapter) sendWorkNotice(ctx context.Context, message *dto.UnifiedMessage, config map[string]interface{}, accessToken string) error {

--- a/internal/adapter/dingtalk_enterprise/adapter_test.go
+++ b/internal/adapter/dingtalk_enterprise/adapter_test.go
@@ -13,7 +13,7 @@ import (
 func TestNewAdapter(t *testing.T) {
 	logger := zerolog.Nop()
 	adapter := NewAdapter(logger)
-	
+
 	assert.NotNil(t, adapter)
 	assert.NotNil(t, adapter.httpClient)
 	assert.NotNil(t, adapter.tokenCache)
@@ -23,7 +23,7 @@ func TestNewAdapter(t *testing.T) {
 func TestGetPlatformType(t *testing.T) {
 	logger := zerolog.Nop()
 	adapter := NewAdapter(logger)
-	
+
 	platformType := adapter.GetPlatformType()
 	assert.Equal(t, entity.PlatformTypeDingtalk, platformType)
 }
@@ -31,7 +31,7 @@ func TestGetPlatformType(t *testing.T) {
 func TestValidateConfig(t *testing.T) {
 	logger := zerolog.Nop()
 	adapter := NewAdapter(logger)
-	
+
 	tests := []struct {
 		name    string
 		config  map[string]interface{}
@@ -71,7 +71,7 @@ func TestValidateConfig(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := adapter.ValidateConfig(tt.config)
@@ -121,12 +121,12 @@ func TestBuildDingtalkMessage(t *testing.T) {
 			},
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := buildDingtalkMessage(tt.message)
 			assert.Equal(t, tt.expected["msgtype"], result["msgtype"])
-			
+
 			// 验证具体内容
 			if textContent, ok := tt.expected["text"]; ok {
 				assert.Equal(t, textContent, result["text"])
@@ -146,7 +146,7 @@ func TestParseEnterpriseConfig(t *testing.T) {
 		"corp_id":      "test_corp",
 		"message_mode": "group_chat",
 	}
-	
+
 	cfg, err := ParseEnterpriseConfig(config)
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)
@@ -160,16 +160,16 @@ func TestParseEnterpriseConfig(t *testing.T) {
 func TestTokenCaching(t *testing.T) {
 	logger := zerolog.Nop()
 	adapter := NewAdapter(logger)
-	
+
 	// 测试缓存键生成
 	config := map[string]interface{}{
 		"app_key":    "test_key",
 		"app_secret": "test_secret",
 	}
-	
+
 	// 由于GetAccessToken需要实际的API调用，这里只测试缓存逻辑
 	ctx := context.Background()
-	
+
 	// 第一次调用会失败（因为是测试环境），但应该不会panic
 	_, err := adapter.GetAccessToken(ctx, config)
 	assert.Error(t, err) // 预期会失败，因为没有真实的API
@@ -178,12 +178,12 @@ func TestTokenCaching(t *testing.T) {
 func TestSendMessageRouting(t *testing.T) {
 	logger := zerolog.Nop()
 	adapter := NewAdapter(logger)
-	
+
 	ctx := context.Background()
 	config := map[string]interface{}{
 		"agent_id": "test_agent",
 	}
-	
+
 	tests := []struct {
 		name         string
 		message      *dto.UnifiedMessage
@@ -206,7 +206,7 @@ func TestSendMessageRouting(t *testing.T) {
 			expectMethod: "group_message",
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// 由于需要实际的access token和API调用，这里只验证不会panic
@@ -214,4 +214,4 @@ func TestSendMessageRouting(t *testing.T) {
 			assert.Error(t, err) // 预期会失败，但不应该panic
 		})
 	}
-} 
+}

--- a/internal/adapter/dingtalk_proxy/adapter.go
+++ b/internal/adapter/dingtalk_proxy/adapter.go
@@ -17,6 +17,14 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
 )
 
+// 编译期接口实现检查
+var _ port.MessageSender = (*DingtalkProxyAdapter)(nil)
+var _ port.WebhookProcessor = (*DingtalkProxyAdapter)(nil)
+var _ port.TokenManager = (*DingtalkProxyAdapter)(nil)
+var _ port.StreamAdapter = (*DingtalkProxyAdapter)(nil)
+var _ port.PlatformIdentifier = (*DingtalkProxyAdapter)(nil)
+var _ port.ConfigValidator = (*DingtalkProxyAdapter)(nil)
+
 // DingtalkProxyAdapter 钉钉适配器代理，根据配置选择具体实现
 type DingtalkProxyAdapter struct {
 	logger            zerolog.Logger
@@ -84,13 +92,7 @@ func (a *DingtalkProxyAdapter) ProcessWebhookMessage(ctx context.Context, reques
 }
 
 // VerifyWebhook 实现WebhookProcessor接口
-func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, timestamp, nonce string, body []byte, config entity.JSONField) error {
-	// 根据配置判断使用哪种验证方式
-	cfg := make(map[string]interface{})
-	if err := config.Scan(&cfg); err != nil {
-		return err
-	}
-
+func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, timestamp, nonce string, body []byte, cfg map[string]interface{}) error {
 	if isStreamMode(cfg) {
 		// Stream模式不需要验证Webhook
 		return fmt.Errorf("stream mode does not support webhook")
@@ -103,7 +105,6 @@ func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, tim
 		return fmt.Errorf("app_secret not found in config for webhook verification")
 	}
 
-	// 使用企业应用适配器的验证逻辑
 	// 钉钉企业应用的签名验证算法：
 	// 1. 把timestamp + "\n" + secret当做签名字符串
 	// 2. 使用HmacSHA256算法计算签名
@@ -121,12 +122,7 @@ func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, tim
 }
 
 // ParseInboundMessage 实现WebhookProcessor接口
-func (a *DingtalkProxyAdapter) ParseInboundMessage(ctx context.Context, body []byte, config entity.JSONField) (*dto.UnifiedMessage, error) {
-	cfg := make(map[string]interface{})
-	if err := config.Scan(&cfg); err != nil {
-		return nil, err
-	}
-
+func (a *DingtalkProxyAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
 	if isStreamMode(cfg) {
 		return nil, fmt.Errorf("stream mode does not support webhook parsing")
 	}
@@ -138,6 +134,11 @@ func (a *DingtalkProxyAdapter) ParseInboundMessage(ctx context.Context, body []b
 	}
 
 	return webhookData.ToUnifiedMessage(), nil
+}
+
+// BuildWebhookPath 实现WebhookProcessor接口
+func (a *DingtalkProxyAdapter) BuildWebhookPath(channelID int64) string {
+	return fmt.Sprintf("/webhook/dingtalk/%d", channelID)
 }
 
 // Start 实现StreamAdapter接口

--- a/internal/adapter/dingtalk_proxy/adapter.go
+++ b/internal/adapter/dingtalk_proxy/adapter.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,13 +18,23 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
 )
 
-// 编译期接口实现检查
-var _ port.MessageSender = (*DingtalkProxyAdapter)(nil)
-var _ port.WebhookProcessor = (*DingtalkProxyAdapter)(nil)
-var _ port.TokenManager = (*DingtalkProxyAdapter)(nil)
-var _ port.StreamAdapter = (*DingtalkProxyAdapter)(nil)
-var _ port.PlatformIdentifier = (*DingtalkProxyAdapter)(nil)
-var _ port.ConfigValidator = (*DingtalkProxyAdapter)(nil)
+var (
+	errProxyStreamNoWebhook      = errors.New("stream mode does not support webhook")
+	errProxyMissingWebhookSecret = errors.New("app_secret not found in config for webhook verification")
+	errProxyWebhookSigFailed     = errors.New("webhook signature verification failed")
+	errProxyStreamNoWebhookParse = errors.New("stream mode does not support webhook parsing")
+	errProxyEnterpriseNoStream   = errors.New("enterprise mode does not support stream connection")
+)
+
+// 编译期接口实现检查。
+var (
+	_ port.MessageSender      = (*DingtalkProxyAdapter)(nil)
+	_ port.WebhookProcessor   = (*DingtalkProxyAdapter)(nil)
+	_ port.TokenManager       = (*DingtalkProxyAdapter)(nil)
+	_ port.StreamAdapter      = (*DingtalkProxyAdapter)(nil)
+	_ port.PlatformIdentifier = (*DingtalkProxyAdapter)(nil)
+	_ port.ConfigValidator    = (*DingtalkProxyAdapter)(nil)
+)
 
 // DingtalkProxyAdapter 钉钉适配器代理，根据配置选择具体实现
 type DingtalkProxyAdapter struct {
@@ -35,7 +46,8 @@ type DingtalkProxyAdapter struct {
 // NewAdapter 创建钉钉代理适配器
 func NewAdapter(logger zerolog.Logger,
 	streamAdapter *dingtalk_stream.DingtalkStreamAdapter,
-	enterpriseAdapter *dingtalk_enterprise.DingtalkEnterpriseAdapter) *DingtalkProxyAdapter {
+	enterpriseAdapter *dingtalk_enterprise.DingtalkEnterpriseAdapter,
+) *DingtalkProxyAdapter {
 	return &DingtalkProxyAdapter{
 		logger:            logger,
 		streamAdapter:     streamAdapter,
@@ -91,18 +103,18 @@ func (a *DingtalkProxyAdapter) ProcessWebhookMessage(ctx context.Context, reques
 	return nil, fmt.Errorf("invalid webhook request")
 }
 
-// VerifyWebhook 实现WebhookProcessor接口
-func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, timestamp, nonce string, body []byte, cfg map[string]interface{}) error {
+// VerifyWebhook 实现WebhookProcessor接口。
+func (a *DingtalkProxyAdapter) VerifyWebhook(_ context.Context, signature, timestamp, _ string, _ []byte, cfg map[string]interface{}) error {
 	if isStreamMode(cfg) {
 		// Stream模式不需要验证Webhook
-		return fmt.Errorf("stream mode does not support webhook")
+		return errProxyStreamNoWebhook
 	}
 
 	// 企业应用模式验证
 	// 从配置中获取app_secret
 	appSecret, ok := cfg["app_secret"].(string)
 	if !ok || appSecret == "" {
-		return fmt.Errorf("app_secret not found in config for webhook verification")
+		return errProxyMissingWebhookSecret
 	}
 
 	// 钉钉企业应用的签名验证算法：
@@ -114,17 +126,19 @@ func (a *DingtalkProxyAdapter) VerifyWebhook(ctx context.Context, signature, tim
 			Str("signature", signature).
 			Str("timestamp", timestamp).
 			Msg("钉钉企业应用Webhook签名验证失败")
-		return fmt.Errorf("webhook signature verification failed")
+
+		return errProxyWebhookSigFailed
 	}
 
 	a.logger.Debug().Msg("钉钉企业应用Webhook签名验证成功")
+
 	return nil
 }
 
-// ParseInboundMessage 实现WebhookProcessor接口
-func (a *DingtalkProxyAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
+// ParseInboundMessage 实现WebhookProcessor接口。
+func (a *DingtalkProxyAdapter) ParseInboundMessage(_ context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
 	if isStreamMode(cfg) {
-		return nil, fmt.Errorf("stream mode does not support webhook parsing")
+		return nil, errProxyStreamNoWebhookParse
 	}
 
 	// 解析企业应用的Webhook消息
@@ -136,15 +150,15 @@ func (a *DingtalkProxyAdapter) ParseInboundMessage(ctx context.Context, body []b
 	return webhookData.ToUnifiedMessage(), nil
 }
 
-// BuildWebhookPath 实现WebhookProcessor接口
+// BuildWebhookPath 实现WebhookProcessor接口。
 func (a *DingtalkProxyAdapter) BuildWebhookPath(channelID int64) string {
 	return fmt.Sprintf("/webhook/dingtalk/%d", channelID)
 }
 
-// Start 实现StreamAdapter接口
+// Start 实现StreamAdapter接口。
 func (a *DingtalkProxyAdapter) Start(ctx context.Context, messageHandler port.MessageHandler, cfg map[string]interface{}) error {
 	if !isStreamMode(cfg) {
-		return fmt.Errorf("enterprise mode does not support stream connection")
+		return errProxyEnterpriseNoStream
 	}
 	return a.streamAdapter.Start(ctx, messageHandler, cfg)
 }

--- a/internal/adapter/dingtalk_stream/adapter.go
+++ b/internal/adapter/dingtalk_stream/adapter.go
@@ -287,10 +287,10 @@ func (a *DingtalkStreamAdapter) Start(ctx context.Context, messageHandler port.M
 		logger:  a.logger,
 	}
 
-	// 创建Stream控制器（假设channelID从config中获取）
-	channelID := "1" // 这里应该从config中获取，或者作为参数传入
-	if channelIDValue, ok := cfg["channel_id"].(string); ok {
-		channelID = channelIDValue
+	// 从配置中获取channelID，channel_id为必填项
+	channelID, ok := cfg["channel_id"].(string)
+	if !ok || channelID == "" {
+		return fmt.Errorf("channel_id is required in dingtalk stream config")
 	}
 
 	a.streamController = NewStreamController(

--- a/internal/adapter/dingtalk_stream/adapter.go
+++ b/internal/adapter/dingtalk_stream/adapter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -15,6 +16,8 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
 )
+
+var errStreamMissingChannelID = errors.New("channel_id is required in dingtalk stream config")
 
 // DingtalkStreamAdapter 钉钉Stream适配器，实现MessageSender, StreamAdapter, PlatformIdentifier, ConfigValidator接口
 type DingtalkStreamAdapter struct {
@@ -290,7 +293,7 @@ func (a *DingtalkStreamAdapter) Start(ctx context.Context, messageHandler port.M
 	// 从配置中获取channelID，channel_id为必填项
 	channelID, ok := cfg["channel_id"].(string)
 	if !ok || channelID == "" {
-		return fmt.Errorf("channel_id is required in dingtalk stream config")
+		return errStreamMissingChannelID
 	}
 
 	a.streamController = NewStreamController(

--- a/internal/adapter/dingtalk_stream/stream_controller.go
+++ b/internal/adapter/dingtalk_stream/stream_controller.go
@@ -3,6 +3,7 @@ package dingtalk_stream
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
@@ -27,6 +28,7 @@ type StreamController struct {
 	config         *config.DingtalkStreamConfig
 	channelID      string
 	isRunning      bool
+	mu             sync.RWMutex
 }
 
 // NewStreamController 创建钉钉Stream控制器
@@ -47,6 +49,9 @@ func NewStreamController(
 
 // Start 启动钉钉Stream客户端
 func (c *StreamController) Start(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.isRunning {
 		return fmt.Errorf("dingtalk stream controller is already running")
 	}
@@ -66,10 +71,12 @@ func (c *StreamController) Start(ctx context.Context) error {
 
 	c.logger.Info().Msg("dingtalk stream controller started")
 
-	// 在goroutine中运行客户端
+	// 在goroutine中运行客户端，ctx取消时客户端退出
 	go func() {
 		defer func() {
+			c.mu.Lock()
 			c.isRunning = false
+			c.mu.Unlock()
 			c.logger.Info().Msg("dingtalk stream controller stopped")
 		}()
 
@@ -84,6 +91,9 @@ func (c *StreamController) Start(ctx context.Context) error {
 
 // Stop 停止钉钉Stream客户端
 func (c *StreamController) Stop() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if !c.isRunning {
 		return nil
 	}
@@ -100,6 +110,8 @@ func (c *StreamController) Stop() error {
 
 // IsRunning 检查是否正在运行
 func (c *StreamController) IsRunning() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.isRunning
 }
 

--- a/internal/adapter/feishu/adapter.go
+++ b/internal/adapter/feishu/adapter.go
@@ -2,7 +2,9 @@ package feishu
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -111,8 +113,14 @@ func (f *FeishuAdapter) getClient(cfg map[string]interface{}) (*lark.Client, err
 		return f.client, nil
 	}
 
-	appID := cfg["app_id"].(string)
-	appSecret := cfg["app_secret"].(string)
+	appID, ok := cfg["app_id"].(string)
+	if !ok || appID == "" {
+		return nil, fmt.Errorf("app_id is required in feishu config")
+	}
+	appSecret, ok := cfg["app_secret"].(string)
+	if !ok || appSecret == "" {
+		return nil, fmt.Errorf("app_secret is required in feishu config")
+	}
 
 	// 创建飞书客户端
 	client := lark.NewClient(appID, appSecret, lark.WithLogLevel(larkcore.LogLevelError))
@@ -121,7 +129,103 @@ func (f *FeishuAdapter) getClient(cfg map[string]interface{}) (*lark.Client, err
 	return client, nil
 }
 
+// VerifyWebhook 实现WebhookProcessor接口
+// 飞书使用 challenge 机制进行验证，此处验证 verification_token
+func (f *FeishuAdapter) VerifyWebhook(ctx context.Context, signature string, timestamp string, nonce string, body []byte, cfg map[string]interface{}) error {
+	// 飞书的 URL 验证通过解析 challenge 完成，签名验证由 SDK 内部处理
+	// 这里仅做基础的 token 校验（如配置了 verification_token）
+	verificationToken, _ := cfg["verification_token"].(string)
+	if verificationToken == "" {
+		// 未配置 token 时跳过验证
+		return nil
+	}
+
+	// 解析请求体检查 token
+	var event map[string]interface{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return fmt.Errorf("failed to parse feishu webhook body: %w", err)
+	}
+
+	// 飞书回调中 token 字段在顶层
+	if token, ok := event["token"].(string); ok && token != verificationToken {
+		return fmt.Errorf("feishu webhook token mismatch")
+	}
+
+	return nil
+}
+
+// ParseInboundMessage 实现WebhookProcessor接口
+func (f *FeishuAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
+	var event map[string]interface{}
+	if err := json.Unmarshal(body, &event); err != nil {
+		return nil, fmt.Errorf("failed to parse feishu webhook body: %w", err)
+	}
+
+	// 处理飞书 URL 验证挑战
+	if challenge, ok := event["challenge"].(string); ok {
+		return &dto.UnifiedMessage{
+			MessageID:   fmt.Sprintf("feishu_challenge_%d", time.Now().UnixNano()),
+			MessageType: entity.MessageTypeEvent,
+			Content:     challenge,
+			RawContent:  map[string]interface{}{"challenge": challenge, "type": "url_verification"},
+		}, nil
+	}
+
+	// 解析飞书事件消息
+	header, _ := event["header"].(map[string]interface{})
+	eventData, _ := event["event"].(map[string]interface{})
+
+	eventType := ""
+	if header != nil {
+		eventType, _ = header["event_type"].(string)
+	}
+
+	msg := &dto.UnifiedMessage{
+		MessageType:       entity.MessageTypeEvent,
+		RawContent:        event,
+		PlatformTimestamp: time.Now(),
+	}
+
+	if eventID, ok := header["event_id"].(string); ok {
+		msg.MessageID = fmt.Sprintf("feishu_%s", eventID)
+		msg.PlatformMessageID = eventID
+	}
+
+	switch eventType {
+	case "im.message.receive_v1":
+		if eventData != nil {
+			msg.MessageType = entity.MessageTypeText
+			if sender, ok := eventData["sender"].(map[string]interface{}); ok {
+				msg.SenderID, _ = sender["sender_id"].(string)
+				msg.SenderType = entity.SenderTypeUser
+			}
+			if message, ok := eventData["message"].(map[string]interface{}); ok {
+				msg.Content, _ = message["content"].(string)
+				if msgType, ok := message["msg_type"].(string); ok {
+					msg.MessageType = msgType
+				}
+				if msgID, ok := message["message_id"].(string); ok {
+					msg.PlatformMessageID = msgID
+					msg.MessageID = fmt.Sprintf("feishu_%s", msgID)
+				}
+				if chatID, ok := message["chat_id"].(string); ok {
+					msg.ConversationID = chatID
+					msg.ReceiverID = chatID
+				}
+			}
+		}
+	}
+
+	return msg, nil
+}
+
+// BuildWebhookPath 实现WebhookProcessor接口
+func (f *FeishuAdapter) BuildWebhookPath(channelID int64) string {
+	return fmt.Sprintf("/webhook/feishu/%d", channelID)
+}
+
 // 确保 FeishuAdapter 实现了所需的接口
 var _ port.MessageSender = (*FeishuAdapter)(nil)
+var _ port.WebhookProcessor = (*FeishuAdapter)(nil)
 var _ port.PlatformIdentifier = (*FeishuAdapter)(nil)
 var _ port.ConfigValidator = (*FeishuAdapter)(nil)

--- a/internal/adapter/feishu/adapter.go
+++ b/internal/adapter/feishu/adapter.go
@@ -3,6 +3,7 @@ package feishu
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,12 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/dto"
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
+)
+
+var (
+	errFeishuMissingAppID         = errors.New("app_id is required in feishu config")
+	errFeishuMissingAppSecret     = errors.New("app_secret is required in feishu config")
+	errFeishuWebhookTokenMismatch = errors.New("feishu webhook token mismatch")
 )
 
 // FeishuAdapter 飞书平台适配器
@@ -115,27 +122,29 @@ func (f *FeishuAdapter) getClient(cfg map[string]interface{}) (*lark.Client, err
 
 	appID, ok := cfg["app_id"].(string)
 	if !ok || appID == "" {
-		return nil, fmt.Errorf("app_id is required in feishu config")
+		return nil, errFeishuMissingAppID
 	}
+
 	appSecret, ok := cfg["app_secret"].(string)
 	if !ok || appSecret == "" {
-		return nil, fmt.Errorf("app_secret is required in feishu config")
+		return nil, errFeishuMissingAppSecret
 	}
 
 	// 创建飞书客户端
 	client := lark.NewClient(appID, appSecret, lark.WithLogLevel(larkcore.LogLevelError))
 
 	f.client = client
+
 	return client, nil
 }
 
-// VerifyWebhook 实现WebhookProcessor接口
-// 飞书使用 challenge 机制进行验证，此处验证 verification_token
-func (f *FeishuAdapter) VerifyWebhook(ctx context.Context, signature string, timestamp string, nonce string, body []byte, cfg map[string]interface{}) error {
+// VerifyWebhook 实现WebhookProcessor接口。
+// 飞书使用 challenge 机制进行验证，此处验证 verification_token。
+func (f *FeishuAdapter) VerifyWebhook(_ context.Context, _, _, _ string, body []byte, cfg map[string]interface{}) error {
 	// 飞书的 URL 验证通过解析 challenge 完成，签名验证由 SDK 内部处理
 	// 这里仅做基础的 token 校验（如配置了 verification_token）
-	verificationToken, _ := cfg["verification_token"].(string)
-	if verificationToken == "" {
+	verificationToken, ok := cfg["verification_token"].(string)
+	if !ok || verificationToken == "" {
 		// 未配置 token 时跳过验证
 		return nil
 	}
@@ -148,14 +157,14 @@ func (f *FeishuAdapter) VerifyWebhook(ctx context.Context, signature string, tim
 
 	// 飞书回调中 token 字段在顶层
 	if token, ok := event["token"].(string); ok && token != verificationToken {
-		return fmt.Errorf("feishu webhook token mismatch")
+		return errFeishuWebhookTokenMismatch
 	}
 
 	return nil
 }
 
-// ParseInboundMessage 实现WebhookProcessor接口
-func (f *FeishuAdapter) ParseInboundMessage(ctx context.Context, body []byte, cfg map[string]interface{}) (*dto.UnifiedMessage, error) {
+// ParseInboundMessage 实现WebhookProcessor接口。
+func (f *FeishuAdapter) ParseInboundMessage(_ context.Context, body []byte, _ map[string]interface{}) (*dto.UnifiedMessage, error) {
 	var event map[string]interface{}
 	if err := json.Unmarshal(body, &event); err != nil {
 		return nil, fmt.Errorf("failed to parse feishu webhook body: %w", err)
@@ -172,12 +181,22 @@ func (f *FeishuAdapter) ParseInboundMessage(ctx context.Context, body []byte, cf
 	}
 
 	// 解析飞书事件消息
-	header, _ := event["header"].(map[string]interface{})
-	eventData, _ := event["event"].(map[string]interface{})
+	var header map[string]interface{}
+	if v, ok := event["header"].(map[string]interface{}); ok {
+		header = v
+	}
+
+	var eventData map[string]interface{}
+	if v, ok := event["event"].(map[string]interface{}); ok {
+		eventData = v
+	}
 
 	eventType := ""
+
 	if header != nil {
-		eventType, _ = header["event_type"].(string)
+		if v, ok := header["event_type"].(string); ok {
+			eventType = v
+		}
 	}
 
 	msg := &dto.UnifiedMessage{
@@ -186,46 +205,69 @@ func (f *FeishuAdapter) ParseInboundMessage(ctx context.Context, body []byte, cf
 		PlatformTimestamp: time.Now(),
 	}
 
-	if eventID, ok := header["event_id"].(string); ok {
-		msg.MessageID = fmt.Sprintf("feishu_%s", eventID)
-		msg.PlatformMessageID = eventID
+	if header != nil {
+		if eventID, ok := header["event_id"].(string); ok {
+			msg.MessageID = fmt.Sprintf("feishu_%s", eventID)
+			msg.PlatformMessageID = eventID
+		}
 	}
 
-	switch eventType {
-	case "im.message.receive_v1":
-		if eventData != nil {
-			msg.MessageType = entity.MessageTypeText
-			if sender, ok := eventData["sender"].(map[string]interface{}); ok {
-				msg.SenderID, _ = sender["sender_id"].(string)
-				msg.SenderType = entity.SenderTypeUser
-			}
-			if message, ok := eventData["message"].(map[string]interface{}); ok {
-				msg.Content, _ = message["content"].(string)
-				if msgType, ok := message["msg_type"].(string); ok {
-					msg.MessageType = msgType
-				}
-				if msgID, ok := message["message_id"].(string); ok {
-					msg.PlatformMessageID = msgID
-					msg.MessageID = fmt.Sprintf("feishu_%s", msgID)
-				}
-				if chatID, ok := message["chat_id"].(string); ok {
-					msg.ConversationID = chatID
-					msg.ReceiverID = chatID
-				}
-			}
-		}
+	if eventType == "im.message.receive_v1" {
+		f.handleMessageReceiveEvent(eventData, msg)
 	}
 
 	return msg, nil
 }
 
-// BuildWebhookPath 实现WebhookProcessor接口
+// handleMessageReceiveEvent 处理飞书 im.message.receive_v1 事件。
+func (f *FeishuAdapter) handleMessageReceiveEvent(eventData map[string]interface{}, msg *dto.UnifiedMessage) {
+	if eventData == nil {
+		return
+	}
+
+	msg.MessageType = entity.MessageTypeText
+
+	if sender, ok := eventData["sender"].(map[string]interface{}); ok {
+		if senderID, ok := sender["sender_id"].(string); ok {
+			msg.SenderID = senderID
+		}
+
+		msg.SenderType = entity.SenderTypeUser
+	}
+
+	message, ok := eventData["message"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	if content, ok := message["content"].(string); ok {
+		msg.Content = content
+	}
+
+	if msgType, ok := message["msg_type"].(string); ok {
+		msg.MessageType = msgType
+	}
+
+	if msgID, ok := message["message_id"].(string); ok {
+		msg.PlatformMessageID = msgID
+		msg.MessageID = fmt.Sprintf("feishu_%s", msgID)
+	}
+
+	if chatID, ok := message["chat_id"].(string); ok {
+		msg.ConversationID = chatID
+		msg.ReceiverID = chatID
+	}
+}
+
+// BuildWebhookPath 实现WebhookProcessor接口。
 func (f *FeishuAdapter) BuildWebhookPath(channelID int64) string {
 	return fmt.Sprintf("/webhook/feishu/%d", channelID)
 }
 
-// 确保 FeishuAdapter 实现了所需的接口
-var _ port.MessageSender = (*FeishuAdapter)(nil)
-var _ port.WebhookProcessor = (*FeishuAdapter)(nil)
-var _ port.PlatformIdentifier = (*FeishuAdapter)(nil)
-var _ port.ConfigValidator = (*FeishuAdapter)(nil)
+// 确保 FeishuAdapter 实现了所需的接口。
+var (
+	_ port.MessageSender      = (*FeishuAdapter)(nil)
+	_ port.WebhookProcessor   = (*FeishuAdapter)(nil)
+	_ port.PlatformIdentifier = (*FeishuAdapter)(nil)
+	_ port.ConfigValidator    = (*FeishuAdapter)(nil)
+)

--- a/internal/adapter/manager.go
+++ b/internal/adapter/manager.go
@@ -2,12 +2,15 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/sivdead/OmniBotGo/internal/dto"
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
 )
+
+var errAIModelNotImplemented = errors.New("AI model management is not implemented yet")
 
 // Manager 平台适配器管理器
 type Manager struct {
@@ -140,6 +143,7 @@ func (m *Manager) VerifyWebhook(ctx context.Context, platformType entity.Platfor
 	if err != nil {
 		return err
 	}
+
 	return processor.VerifyWebhook(ctx, signature, timestamp, nonce, body, map[string]interface{}(config))
 }
 
@@ -149,6 +153,7 @@ func (m *Manager) ParseInboundMessage(ctx context.Context, platformType entity.P
 	if err != nil {
 		return nil, err
 	}
+
 	return processor.ParseInboundMessage(ctx, body, map[string]interface{}(config))
 }
 
@@ -162,17 +167,17 @@ func (m *Manager) GetAIModelManager() port.AIModelManager {
 	return &notImplementedAIModelManager{}
 }
 
-// notImplementedAIModelManager 占位实现，所有方法返回"未实现"错误
+// notImplementedAIModelManager 占位实现，所有方法返回"未实现"错误。
 type notImplementedAIModelManager struct{}
 
-func (n *notImplementedAIModelManager) CreateChatModel(ctx context.Context, provider string, config map[string]interface{}) (interface{}, error) {
-	return nil, fmt.Errorf("AI model management is not implemented yet")
+func (n *notImplementedAIModelManager) CreateChatModel(_ context.Context, _ string, _ map[string]interface{}) (interface{}, error) {
+	return nil, errAIModelNotImplemented
 }
 
 func (n *notImplementedAIModelManager) GetSupportedProviders() []string {
 	return nil
 }
 
-func (n *notImplementedAIModelManager) ValidateConfig(provider string, config map[string]interface{}) error {
-	return fmt.Errorf("AI model management is not implemented yet")
+func (n *notImplementedAIModelManager) ValidateConfig(_ string, _ map[string]interface{}) error {
+	return errAIModelNotImplemented
 }

--- a/internal/adapter/manager.go
+++ b/internal/adapter/manager.go
@@ -140,7 +140,7 @@ func (m *Manager) VerifyWebhook(ctx context.Context, platformType entity.Platfor
 	if err != nil {
 		return err
 	}
-	return processor.VerifyWebhook(ctx, signature, timestamp, nonce, body, config)
+	return processor.VerifyWebhook(ctx, signature, timestamp, nonce, body, map[string]interface{}(config))
 }
 
 // ParseInboundMessage 解析入站消息
@@ -149,7 +149,7 @@ func (m *Manager) ParseInboundMessage(ctx context.Context, platformType entity.P
 	if err != nil {
 		return nil, err
 	}
-	return processor.ParseInboundMessage(ctx, body, config)
+	return processor.ParseInboundMessage(ctx, body, map[string]interface{}(config))
 }
 
 // BuildWebhookPath 构建Webhook路径
@@ -158,8 +158,21 @@ func (m *Manager) BuildWebhookPath(platformType entity.PlatformType, channelID i
 }
 
 // GetAIModelManager 获取AI模型管理器
-// TODO: 实现完整的AI模型管理功能
 func (m *Manager) GetAIModelManager() port.AIModelManager {
-	// 临时返回 nil，实际应该返回具体的 AI 模型管理器实现
+	return &notImplementedAIModelManager{}
+}
+
+// notImplementedAIModelManager 占位实现，所有方法返回"未实现"错误
+type notImplementedAIModelManager struct{}
+
+func (n *notImplementedAIModelManager) CreateChatModel(ctx context.Context, provider string, config map[string]interface{}) (interface{}, error) {
+	return nil, fmt.Errorf("AI model management is not implemented yet")
+}
+
+func (n *notImplementedAIModelManager) GetSupportedProviders() []string {
 	return nil
+}
+
+func (n *notImplementedAIModelManager) ValidateConfig(provider string, config map[string]interface{}) error {
+	return fmt.Errorf("AI model management is not implemented yet")
 }

--- a/internal/adapter/wechat_official/adapter.go
+++ b/internal/adapter/wechat_official/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,13 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/dto"
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
+)
+
+var (
+	errWechatOfficialMissingAppID     = errors.New("app_id is required in wechat official config")
+	errWechatOfficialMissingAppSecret = errors.New("app_secret is required in wechat official config")
+	errWechatOfficialMissingToken     = errors.New("token is required in wechat official config for webhook verification")
+	errWechatOfficialInvalidSignature = errors.New("invalid signature")
 )
 
 // WechatOfficialAdapter 微信公众号平台适配器
@@ -136,11 +144,12 @@ func (w *WechatOfficialAdapter) SendMessage(ctx context.Context, message *dto.Un
 func (w *WechatOfficialAdapter) GetAccessToken(ctx context.Context, config map[string]interface{}) (*dto.AccessTokenResponse, error) {
 	appID, ok := config["app_id"].(string)
 	if !ok || appID == "" {
-		return nil, fmt.Errorf("app_id is required in wechat official config")
+		return nil, errWechatOfficialMissingAppID
 	}
+
 	appSecret, ok := config["app_secret"].(string)
 	if !ok || appSecret == "" {
-		return nil, fmt.Errorf("app_secret is required in wechat official config")
+		return nil, errWechatOfficialMissingAppSecret
 	}
 
 	reqURL := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=%s&secret=%s", appID, appSecret)
@@ -189,7 +198,7 @@ func (w *WechatOfficialAdapter) RefreshAccessToken(ctx context.Context, config m
 func (w *WechatOfficialAdapter) VerifyWebhook(ctx context.Context, signature string, timestamp string, nonce string, body []byte, config map[string]interface{}) error {
 	token, ok := config["token"].(string)
 	if !ok || token == "" {
-		return fmt.Errorf("token is required in wechat official config for webhook verification")
+		return errWechatOfficialMissingToken
 	}
 
 	// 微信公众号签名验证
@@ -202,7 +211,7 @@ func (w *WechatOfficialAdapter) VerifyWebhook(ctx context.Context, signature str
 	expectedSignature := fmt.Sprintf("%x", hash.Sum(nil))
 
 	if signature != expectedSignature {
-		return fmt.Errorf("invalid signature")
+		return errWechatOfficialInvalidSignature
 	}
 
 	return nil
@@ -311,9 +320,11 @@ func getString(m map[string]interface{}, key string) string {
 	return ""
 }
 
-// 确保 WechatOfficialAdapter 实现了所需的接口
-var _ port.MessageSender = (*WechatOfficialAdapter)(nil)
-var _ port.TokenManager = (*WechatOfficialAdapter)(nil)
-var _ port.WebhookProcessor = (*WechatOfficialAdapter)(nil)
-var _ port.PlatformIdentifier = (*WechatOfficialAdapter)(nil)
-var _ port.ConfigValidator = (*WechatOfficialAdapter)(nil)
+// 确保 WechatOfficialAdapter 实现了所需的接口。
+var (
+	_ port.MessageSender      = (*WechatOfficialAdapter)(nil)
+	_ port.TokenManager       = (*WechatOfficialAdapter)(nil)
+	_ port.WebhookProcessor   = (*WechatOfficialAdapter)(nil)
+	_ port.PlatformIdentifier = (*WechatOfficialAdapter)(nil)
+	_ port.ConfigValidator    = (*WechatOfficialAdapter)(nil)
+)

--- a/internal/adapter/wechat_official/adapter.go
+++ b/internal/adapter/wechat_official/adapter.go
@@ -134,8 +134,14 @@ func (w *WechatOfficialAdapter) SendMessage(ctx context.Context, message *dto.Un
 
 // GetAccessToken 获取访问令牌
 func (w *WechatOfficialAdapter) GetAccessToken(ctx context.Context, config map[string]interface{}) (*dto.AccessTokenResponse, error) {
-	appID := config["app_id"].(string)
-	appSecret := config["app_secret"].(string)
+	appID, ok := config["app_id"].(string)
+	if !ok || appID == "" {
+		return nil, fmt.Errorf("app_id is required in wechat official config")
+	}
+	appSecret, ok := config["app_secret"].(string)
+	if !ok || appSecret == "" {
+		return nil, fmt.Errorf("app_secret is required in wechat official config")
+	}
 
 	reqURL := fmt.Sprintf("https://api.weixin.qq.com/cgi-bin/token?grant_type=client_credential&appid=%s&secret=%s", appID, appSecret)
 
@@ -181,7 +187,10 @@ func (w *WechatOfficialAdapter) RefreshAccessToken(ctx context.Context, config m
 
 // VerifyWebhook 验证Webhook请求
 func (w *WechatOfficialAdapter) VerifyWebhook(ctx context.Context, signature string, timestamp string, nonce string, body []byte, config map[string]interface{}) error {
-	token := config["token"].(string)
+	token, ok := config["token"].(string)
+	if !ok || token == "" {
+		return fmt.Errorf("token is required in wechat official config for webhook verification")
+	}
 
 	// 微信公众号签名验证
 	tmpArr := []string{token, timestamp, nonce}

--- a/internal/adapter/wecom/adapter.go
+++ b/internal/adapter/wecom/adapter.go
@@ -44,7 +44,10 @@ func (w *WecomAdapter) ValidateConfig(cfg map[string]interface{}) error {
 
 // SendMessage 发送消息
 func (w *WecomAdapter) SendMessage(ctx context.Context, message *dto.UnifiedMessage, conf map[string]interface{}, accessToken string) error {
-	agentID := conf["agent_id"].(string)
+	agentID, ok := conf["agent_id"].(string)
+	if !ok || agentID == "" {
+		return fmt.Errorf("agent_id is required in wecom config")
+	}
 
 	// 构建企业微信消息格式
 	sendMsg := WecomSendMessage{

--- a/internal/adapter/wecom/adapter.go
+++ b/internal/adapter/wecom/adapter.go
@@ -3,6 +3,7 @@ package wecom
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 	"github.com/sivdead/OmniBotGo/internal/entity"
 	"github.com/sivdead/OmniBotGo/internal/usecase/port"
 )
+
+var errWecomMissingAgentID = errors.New("agent_id is required in wecom config")
 
 // WecomAdapter 企业微信平台适配器
 type WecomAdapter struct {
@@ -46,7 +49,7 @@ func (w *WecomAdapter) ValidateConfig(cfg map[string]interface{}) error {
 func (w *WecomAdapter) SendMessage(ctx context.Context, message *dto.UnifiedMessage, conf map[string]interface{}, accessToken string) error {
 	agentID, ok := conf["agent_id"].(string)
 	if !ok || agentID == "" {
-		return fmt.Errorf("agent_id is required in wecom config")
+		return errWecomMissingAgentID
 	}
 
 	// 构建企业微信消息格式
@@ -284,8 +287,10 @@ func (w *WecomAdapter) RefreshAccessToken(ctx context.Context, config map[string
 	}, nil
 }
 
-// 确保 WecomAdapter 实现了所需的接口
-var _ port.MessageSender = (*WecomAdapter)(nil)
-var _ port.TokenManager = (*WecomAdapter)(nil)
-var _ port.PlatformIdentifier = (*WecomAdapter)(nil)
-var _ port.ConfigValidator = (*WecomAdapter)(nil)
+// 确保 WecomAdapter 实现了所需的接口。
+var (
+	_ port.MessageSender      = (*WecomAdapter)(nil)
+	_ port.TokenManager       = (*WecomAdapter)(nil)
+	_ port.PlatformIdentifier = (*WecomAdapter)(nil)
+	_ port.ConfigValidator    = (*WecomAdapter)(nil)
+)

--- a/internal/controller/http/v1/webhook.go
+++ b/internal/controller/http/v1/webhook.go
@@ -189,9 +189,11 @@ func (w *WebhookController) GetWebhookInfo(c *fiber.Ctx) error {
 		return NewErrorResponse(c, http.StatusNotFound, "通道不存在")
 	}
 
-	// 构建Webhook路径 (临时转换，待后续重构接口)
-	// TODO: 更新 BuildWebhookPath 接口以支持 string channelID
-	channelIDInt, _ := strconv.ParseInt(channelID, 10, 64)
+	// 构建Webhook路径
+	channelIDInt, err := strconv.ParseInt(channelID, 10, 64)
+	if err != nil {
+		return NewErrorResponse(c, http.StatusBadRequest, "通道ID格式错误")
+	}
 	webhookPath, err := w.adapterManager.BuildWebhookPath(platformType, channelIDInt)
 	if err != nil {
 		return NewErrorResponse(c, http.StatusInternalServerError, "构建Webhook路径失败")


### PR DESCRIPTION
- 修复 wecom/wechat_official/feishu/dingtalk_enterprise 中未检查类型断言，
  避免 config key 缺失时 runtime panic
- 修复 dingtalk_proxy VerifyWebhook/ParseInboundMessage 接口签名不一致
  (entity.JSONField → map[string]interface{})，使其正确实现 WebhookProcessor
- 修复 adapter.Manager.VerifyWebhook/ParseInboundMessage 将 entity.JSONField
  显式转换为 map[string]interface{} 再传递给接口方法
- 用 notImplementedAIModelManager stub 替代 GetAIModelManager() 直接返回 nil，
  防止调用方 panic
- 为 dingtalk_enterprise 补全缺失的 VerifyWebhook/ParseInboundMessage/
  BuildWebhookPath 方法，添加编译期接口断言
- 为 feishu 实现 WebhookProcessor 接口（challenge 验证 + 事件解析），
  添加编译期接口断言
- 修复 dingtalk_proxy 添加编译期接口断言
- 修复 dingtalk_stream adapter 中硬编码 channelID="1"，
  改为 channel_id 缺失时返回错误
- 修复 webhook controller ParseInt 忽略错误，改为返回 400
- 修复 stream_controller isRunning 字段无 mutex 保护的数据竞争，
  Start/Stop/IsRunning 均加锁

https://claude.ai/code/session_011naLopoxvews6k1bP3jszk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook support with signature verification and inbound message parsing for multiple messaging platforms

* **Bug Fixes**
  * Configuration validation now provides specific, actionable error messages when required settings are missing or invalid
  * Improved thread-safety with enhanced concurrency protection in streaming connections
  * Strengthened webhook request validation with better error handling and reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->